### PR TITLE
Research theme loading spinner

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -165,5 +165,14 @@
         "qlty",
         "unminified",
         "WCAG"
+    ],
+    "overrides": [
+        {
+            "filename": "AGENTS.md",
+            "words": [
+                "christopherbull",
+                "lighthouserc"
+            ]
+        }
     ]
 }

--- a/.mise.toml
+++ b/.mise.toml
@@ -5,6 +5,10 @@ ruby.compile = false
 node = { version = "24", postinstall = "mise exec -- npm ci" }
 ruby = { version = "3.3.9", postinstall = "mise exec -- bundle config set --local path 'vendor/bundle'; mise exec -- bundle install" }
 
+[tasks.serve]
+description = "Build and serve the site locally (binds 0.0.0.0 for devcontainer)"
+run = "bundle exec jekyll serve --host 0.0.0.0"
+
 [tasks.install-deps]
 description = "Install project dependencies from lockfiles"
 run = [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Dev Container (`.devcontainer/devcontainer.json`) is the recommended environment
 ## Code quality
 
 | Command | Tool | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `npm run lint` | markdownlint-cli2 | MD013 (line length) disabled in `.markdownlint-cli2.jsonc` |
 | `npm run spell` | cspell | Custom dictionaries in `.cspell.json` |
 | `npx commitlint --edit` | commitlint | Enforces Conventional Commits via Husky commit-msg hook |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md — christopherbull.github.io
+
+Personal website built with Jekyll (Minimal Mistakes remote theme), hosted on GitHub Pages.
+
+## Quick start
+
+```bash
+mise install                    # install Node 24 + Ruby 3.3.9
+mise run install-deps           # npm ci + bundle install
+mise run serve                  # local server → http://localhost:4000/ (binds 0.0.0.0 for devcontainer)
+```
+
+Dev Container (`.devcontainer/devcontainer.json`) is the recommended environment.
+
+## Code quality
+
+| Command | Tool | Notes |
+|---|---|---|
+| `npm run lint` | markdownlint-cli2 | MD013 (line length) disabled in `.markdownlint-cli2.jsonc` |
+| `npm run spell` | cspell | Custom dictionaries in `.cspell.json` |
+| `npx commitlint --edit` | commitlint | Enforces Conventional Commits via Husky commit-msg hook |
+
+Run `lint` then `spell` before committing.
+
+## Architecture notes
+
+- **Node.js is tooling-only.** Do not use Node to build/serve the site — that's Jekyll's job.
+- **`_config.yml` excludes** `docs/`, `DEVELOPMENT.md`, `.trunk`, `.qlty` from Jekyll processing.
+- **Navigation** defined in `_data/navigation.yml`.
+- **SEO** uses Schema.org microdata in HTML templates (not JSON-LD). See `docs/seo-microdata.md`.
+- **Lighthouse CI** runs in CI only, configured via `.lighthouserc.js`.
+- **Content pages** live under `research/`, `teaching/`, `profile/`, `about/`, `software/`.

--- a/assets/style/research-themes-mermaid.css
+++ b/assets/style/research-themes-mermaid.css
@@ -28,6 +28,45 @@
     text-decoration: underline;
 }
 
+/* Hide raw mermaid code block before JS transforms it; show loading spinner */
+pre:has(code.language-mermaid) {
+  position: relative;
+  min-height: 250px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+pre:has(code.language-mermaid) code.language-mermaid {
+  display: none;
+}
+
+pre:has(code.language-mermaid)::before {
+  content: "";
+  width: 32px;
+  height: 32px;
+  border: 3px solid #e0e0e0;
+  border-top-color: #1976d2;
+  border-radius: 50%;
+  animation: mermaid-spin 0.8s linear infinite;
+}
+
+pre:has(code.language-mermaid)::after {
+  content: "Herding research themes\2026";
+  color: #666;
+  font-size: 0.9em;
+  font-style: italic;
+}
+
+@keyframes mermaid-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* Centre all Mermaid diagrams */
 .mermaid {
   text-align: center;


### PR DESCRIPTION
### Changes

3 commits on this branch:

1. **AGENTS.md** — repo conventions and quick-start commands for future OpenCode sessions
2. **Mise serve task** — `mise run serve` wraps `jekyll serve --host 0.0.0.0` so the dev server is reachable from the host in a devcontainer
3. **Mermaid loading spinner** — hides the raw code block and shows a CSS spinner + "Herding research themes…" while the CDN module downloads